### PR TITLE
Fix parameter order in createPos function call

### DIFF
--- a/src/app/business/(business-details)/[businessId]/places/[placeId]/pos/action.ts
+++ b/src/app/business/(business-details)/[businessId]/places/[placeId]/pos/action.ts
@@ -37,7 +37,7 @@ export async function addVivaPosAction(
     throw new Error('User does not have access to this place');
   }
 
-  const pos = await createPos(client, id, name, place_id, 'viva', true);
+  const pos = await createPos(client, name, id, place_id, 'viva', true);
   return pos;
 }
 


### PR DESCRIPTION
- Notion : https://www.notion.so/citizenwallet/when-adding-a-terminal-the-id-and-name-are-flipped-compared-to-the-db-fix-this-234c274a65fc8031969fc65b4bb5f2de