### PR TITLE
Update order total and fees calculation to account for corrections

### DIFF
--- a/src/app/business/(business-root)/payouts/new/order-view.tsx
+++ b/src/app/business/(business-root)/payouts/new/order-view.tsx
@@ -60,8 +60,20 @@ export default function OrderView({
   }, [place, dateRange]);
 
   useEffect(() => {
-    const calculatedTotal = orders.reduce((acc, order) => acc + order.total, 0);
-    const calculatedFees = orders.reduce((acc, order) => acc + order.fees, 0);
+
+    const calculatedTotal = orders.reduce(
+      (acc, order) =>
+        acc +
+        (order.status === 'correction' || order.status === 'refund'
+          ? order.total * -1
+          : order.total),
+      0
+    );
+    const calculatedFees = orders.reduce(
+      (acc, order) =>
+        acc + (order.status === 'correction' ? order.fees * -1 : order.fees),
+      0
+    );
 
     setTotal(calculatedTotal - calculatedFees);
   }, [orders]);


### PR DESCRIPTION
- Notion : https://www.notion.so/citizenwallet/new-payout-page-calculation-does-not-take-into-account-refunds-correctly-Total-amount-here-is-bigge-21cc274a65fc80919835fafd0d31cea3